### PR TITLE
feat(graphql): setup graphql subscriptions to the graphql plugin

### DIFF
--- a/examples/blog/app.js
+++ b/examples/blog/app.js
@@ -4,6 +4,7 @@ const { auth } = require('@tensei/auth')
 const { rest } = require('@tensei/rest')
 const { graphql } = require('@tensei/graphql')
 const { tensei, plugin, route } = require('@tensei/core')
+const { RedisPubSub } = require('graphql-redis-subscriptions')
 
 const Tag = require('./resources/Tag')
 const Post = require('./resources/Post')
@@ -58,6 +59,7 @@ module.exports = tensei()
             })
             .plugin(),
         graphql()
+            .subscriptions(new RedisPubSub())
             .middlewareOptions({
                 cors: {
                     credentials: true,

--- a/examples/blog/app.js
+++ b/examples/blog/app.js
@@ -81,7 +81,7 @@ module.exports = tensei()
     .databaseConfig({
         type: process.env.DATABASE_TYPE || 'mysql',
         dbName: process.env.DATABASE_NAME || 'mikrotensei',
-        debug: process.env.DEBUG || true,
+        debug: process.env.DEBUG || false,
         user: process.env.DATABASE_USER || 'mikrotensei',
         password: process.env.DATABASE_PASSWORD || '',
     })

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -10,6 +10,7 @@
         "@slynova/flydrive-s3": "^1.0.3",
         "dotenv": "^8.2.0",
         "faker": "^4.1.0",
+        "graphql-redis-subscriptions": "^2.3.1",
         "pg": "^8.3.3"
     },
     "devDependencies": {

--- a/packages/common/src/api/GraphQlQuery.ts
+++ b/packages/common/src/api/GraphQlQuery.ts
@@ -12,9 +12,11 @@ export class GraphQlQuery implements GraphQlQueryContract {
         name: '',
         internal: false,
         type: 'QUERY',
+        middleware: [],
         snakeCaseName: '',
         paramCaseName: '',
         authorize: [],
+        filter: () => true,
         handler: async () => {}
     }
 
@@ -52,14 +54,32 @@ export class GraphQlQuery implements GraphQlQueryContract {
         return this
     }
 
+    subscription() {
+        this.config.type = 'SUBSCRIPTION'
+
+        return this
+    }
+
     authorize(authorize: AuthorizeFunction) {
         this.config.authorize = [...this.config.authorize, authorize]
 
         return this
     }
 
+    middleware(middleware: GraphQlQueryConfig['handler'][]) {
+        this.config.middleware = [...this.config.middleware, ...middleware]
+
+        return this
+    }
+
     handle(handler: GraphQlQueryConfig['handler']) {
         this.config.handler = handler
+
+        return this
+    }
+
+    filter(filter: GraphQlQueryConfig['filter']) {
+        this.config.filter = filter
 
         return this
     }

--- a/packages/common/src/plugins/Plugin.ts
+++ b/packages/common/src/plugins/Plugin.ts
@@ -4,7 +4,8 @@ import {
     PluginSetupFunction,
     SetupFunctions,
     PluginContract,
-    Permission
+    Permission,
+    ServerStartedPluginSetupFunction
 } from '@tensei/common'
 
 export class Plugin implements PluginContract {
@@ -12,6 +13,7 @@ export class Plugin implements PluginContract {
         permissions: [] as Permission[],
         setup: (config: PluginSetupConfig) => Promise.resolve(),
 
+        serverStarted: () => {},
         beforeDatabaseSetup: (config: PluginSetupConfig) => Promise.resolve(),
         afterDatabaseSetup: (config: PluginSetupConfig) => Promise.resolve(),
 
@@ -43,6 +45,12 @@ export class Plugin implements PluginContract {
 
     public setup(setupFunction: PluginSetupFunction) {
         this.setValue('setup', setupFunction)
+
+        return this
+    }
+
+    public serverStarted(setupFunction: PluginSetupFunction) {
+        this.setValue('serverStarted', setupFunction)
 
         return this
     }

--- a/packages/common/typings/plugins.d.ts
+++ b/packages/common/typings/plugins.d.ts
@@ -1,11 +1,12 @@
 declare module '@tensei/common/plugins' {
     import { Application } from 'express'
     import {
-        StorageManager,
         Storage,
+        StorageManager,
         StorageManagerConfig
     } from '@slynova/flydrive'
     import { DocumentNode } from 'graphql'
+    import { Server } from 'http'
     import { EntityManager } from '@mikro-orm/core'
     import { ResourceContract, ManagerContract } from '@tensei/common/resources'
     import {
@@ -22,6 +23,12 @@ declare module '@tensei/common/plugins' {
 
     type PluginSetupFunction = (config: PluginSetupConfig) => Promise<any>
 
+    type ServerStartedPluginSetupFunction = (
+        config: PluginSetupConfig & {
+            server: Server
+        }
+    ) => void
+
     type SetupFunctions =
         | 'setup'
         | 'beforeDatabaseSetup'
@@ -30,10 +37,12 @@ declare module '@tensei/common/plugins' {
         | 'afterMiddlewareSetup'
         | 'beforeCoreRoutesSetup'
         | 'afterCoreRoutesSetup'
+        | 'serverStarted'
 
     interface PluginSetupConfig extends Config {
         resources: ResourceContract[]
         app: Application
+        server: Server
         resourcesMap: {
             [key: string]: ResourceContract
         }
@@ -63,15 +72,29 @@ declare module '@tensei/common/plugins' {
         slug: string
         data: {
             permissions: Permission[]
-            setup: (config: PluginSetupConfig) => Promise<void>
-            beforeDatabaseSetup: (config: PluginSetupConfig) => Promise<void>
-            afterDatabaseSetup: (config: PluginSetupConfig) => Promise<void>
-            beforeMiddlewareSetup: (config: PluginSetupConfig) => Promise<void>
-            afterMiddlewareSetup: (config: PluginSetupConfig) => Promise<void>
-            beforeCoreRoutesSetup: (config: PluginSetupConfig) => Promise<void>
-            afterCoreRoutesSetup: (config: PluginSetupConfig) => Promise<void>
+            setup: (config: PluginSetupConfig) => void | Promise<void>
+            serverStarted: (config: PluginSetupConfig) => void | Promise<void>
+            beforeDatabaseSetup: (
+                config: PluginSetupConfig
+            ) => void | Promise<void>
+            afterDatabaseSetup: (
+                config: PluginSetupConfig
+            ) => void | Promise<void>
+            beforeMiddlewareSetup: (
+                config: PluginSetupConfig
+            ) => void | Promise<void>
+            afterMiddlewareSetup: (
+                config: PluginSetupConfig
+            ) => void | Promise<void>
+            beforeCoreRoutesSetup: (
+                config: PluginSetupConfig
+            ) => void | Promise<void>
+            afterCoreRoutesSetup: (
+                config: PluginSetupConfig
+            ) => void | Promise<void>
         }
         setup(setupFunction: PluginSetupFunction): this
+        serverStarted: (setupFunction: PluginSetupFunction) => this
         beforeDatabaseSetup(setupFunction: PluginSetupFunction): this
         afterDatabaseSetup(setupFunction: PluginSetupFunction): this
         beforeMiddlewareSetup(setupFunction: PluginSetupFunction): this

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -29,7 +29,8 @@
         "apollo-server-express": "^2.19.0",
         "dataloader": "^2.0.0",
         "graphql-parse-resolve-info": "^4.9.0",
-        "graphql-playground-middleware-express": "^1.7.18"
+        "graphql-playground-middleware-express": "^1.7.18",
+        "graphql-type-json": "^0.3.2"
     },
     "config": {
         "commitizen": {

--- a/packages/graphql/src/Resolvers.ts
+++ b/packages/graphql/src/Resolvers.ts
@@ -1,0 +1,720 @@
+import { parseResolveInfo } from 'graphql-parse-resolve-info'
+import { EntityManager, ReferenceType } from '@mikro-orm/core'
+import {
+    GraphQlQueryContract,
+    ResourceContract,
+    FilterOperators,
+    graphQlQuery,
+    GraphQLPluginContext
+} from '@tensei/common'
+
+export const getResolvers = (
+    resources: ResourceContract[],
+    {
+        subscriptionsEnabled
+    }: {
+        subscriptionsEnabled: boolean
+    }
+) => {
+    const resolversList: GraphQlQueryContract[] = []
+
+    const populateFromResolvedNodes = async (
+        manager: EntityManager,
+        resource: ResourceContract,
+        fieldNode: any,
+        data: any[]
+    ) => {
+        if (!data.length) return
+
+        const relationshipFields = resource.data.fields.filter(
+            f => f.relatedProperty.reference
+        )
+
+        const relatedManyToOneFields = relationshipFields.filter(
+            field =>
+                field.relatedProperty.reference === ReferenceType.MANY_TO_ONE
+        )
+        const relatedManyToManyFields = relationshipFields.filter(
+            field =>
+                field.relatedProperty.reference === ReferenceType.MANY_TO_MANY
+        )
+        const relatedOneToManyFields = relationshipFields.filter(
+            field =>
+                field.relatedProperty.reference === ReferenceType.ONE_TO_MANY
+        )
+        const relatedOneToOneFields = relationshipFields.filter(
+            field =>
+                field.relatedProperty.reference === ReferenceType.ONE_TO_ONE
+        )
+
+        const relatedManyToOneDatabaseFieldNames = relatedManyToOneFields.map(
+            field => field.databaseField
+        )
+        const relatedManyToManyDatabaseFieldNames = relatedManyToManyFields.map(
+            field => field.databaseField
+        )
+        const relatedOneToManyDatabaseFieldNames = relatedOneToManyFields.map(
+            field => field.databaseField
+        )
+        const relatedOneToOneDatabaseFieldNames = relatedOneToOneFields.map(
+            field => field.databaseField
+        )
+
+        if (Object.keys(fieldNode).length > 0) {
+            const countSelections = Object.keys(
+                fieldNode
+            ).filter((selection: string) => selection.match(/__count/))
+            const countSelectionNames: string[] = countSelections.map(
+                (selection: string) => selection.split('__')[0]
+            )
+
+            const manyToOneSelections = Object.keys(
+                fieldNode
+            ).filter((selection: string) =>
+                relatedManyToOneDatabaseFieldNames.includes(selection)
+            )
+            const manyToManySelections = Object.keys(
+                fieldNode
+            ).filter((selection: string) =>
+                relatedManyToManyDatabaseFieldNames.includes(selection)
+            )
+            const oneToManySelections = Object.keys(
+                fieldNode
+            ).filter((selection: string) =>
+                relatedOneToManyDatabaseFieldNames.includes(selection)
+            )
+
+            await Promise.all([
+                Promise.all(
+                    manyToOneSelections.map((selection: string) =>
+                        manager.populate(data, selection)
+                    )
+                ),
+                Promise.all(
+                    manyToManySelections.map((selection: string) =>
+                        (async () => {
+                            const field = relatedManyToManyFields.find(
+                                _ => _.databaseField === selection
+                            )
+
+                            if (
+                                !fieldNode[selection].args.where &&
+                                !fieldNode[selection].args.limit &&
+                                !fieldNode[selection].args.offset
+                            ) {
+                                await manager.populate(data, selection)
+
+                                return
+                            }
+
+                            await Promise.all(
+                                data.map(async item => {
+                                    const relatedData: any = await manager.find(
+                                        field?.relatedProperty.type!,
+                                        {
+                                            [resource.data
+                                                .snakeCaseNamePlural]: {
+                                                id: {
+                                                    $in: [item.id]
+                                                }
+                                            },
+                                            ...parseWhereArgumentsToWhereQuery(
+                                                fieldNode[selection].args.where
+                                            )
+                                        },
+                                        getFindOptionsFromArgs(
+                                            fieldNode[selection].args
+                                        )
+                                    )
+
+                                    item[field?.databaseField!] = relatedData
+                                })
+                            )
+                        })()
+                    )
+                ),
+                Promise.all(
+                    oneToManySelections.map((selection: string) =>
+                        (async () => {
+                            if (
+                                !fieldNode[selection].args.where &&
+                                !fieldNode[selection].args.limit &&
+                                !fieldNode[selection].args.offset
+                            ) {
+                                await manager.populate(data, selection)
+
+                                return
+                            }
+
+                            const field = relatedOneToManyFields.find(
+                                _ => _.databaseField === selection
+                            )
+
+                            await Promise.all(
+                                data.map(async item => {
+                                    const relatedData: any = await manager.find(
+                                        field?.relatedProperty.type!,
+                                        {
+                                            [resource.data.snakeCaseName]:
+                                                item.id,
+                                            ...parseWhereArgumentsToWhereQuery(
+                                                fieldNode[selection].args.where
+                                            )
+                                        },
+                                        getFindOptionsFromArgs(
+                                            fieldNode[selection].args
+                                        )
+                                    )
+
+                                    item[field?.databaseField!] = relatedData
+                                })
+                            )
+                        })()
+                    )
+                ),
+                Promise.all(
+                    countSelectionNames.map(async selection => {
+                        if (
+                            relatedManyToManyDatabaseFieldNames.includes(
+                                selection
+                            )
+                        ) {
+                            const field = relatedManyToManyFields.find(
+                                _ => _.databaseField === selection
+                            )
+
+                            await Promise.all(
+                                data.map(async item => {
+                                    const count = await manager.count(
+                                        field?.relatedProperty.type!,
+                                        {
+                                            [resource.data
+                                                .snakeCaseNamePlural]: {
+                                                id: {
+                                                    $in: [item.id]
+                                                }
+                                            },
+                                            ...parseWhereArgumentsToWhereQuery(
+                                                fieldNode[`${selection}__count`]
+                                                    .args.where
+                                            )
+                                        }
+                                    )
+
+                                    item[
+                                        `${field?.databaseField}__count`
+                                    ] = count
+                                })
+                            )
+                        }
+
+                        if (
+                            relatedOneToManyDatabaseFieldNames.includes(
+                                selection
+                            )
+                        ) {
+                            const field = relatedOneToManyFields.find(
+                                _ => _.databaseField === selection
+                            )
+
+                            const uniqueKeys = Array.from(
+                                new Set(data.map(_ => _.id))
+                            )
+
+                            const counts: any[] = await Promise.all(
+                                uniqueKeys.map(async key =>
+                                    manager.count(
+                                        field?.relatedProperty.type!,
+                                        {
+                                            [resource.data.snakeCaseName]: key,
+                                            ...parseWhereArgumentsToWhereQuery(
+                                                fieldNode[`${selection}__count`]
+                                                    .args.where
+                                            )
+                                        }
+                                    )
+                                )
+                            )
+
+                            data.forEach(item => {
+                                const index = uniqueKeys.indexOf(item.id)
+
+                                item[`${field?.databaseField}__count`] =
+                                    counts[index]
+                            })
+                        }
+                    })
+                )
+            ])
+
+            for (const manyToOneSelection of manyToOneSelections) {
+                const fieldTypes =
+                    fieldNode[manyToOneSelection].fieldsByTypeName
+
+                if (Object.keys(fieldTypes).length > 0) {
+                    const field = relatedManyToOneFields.find(
+                        f => f.databaseField === manyToOneSelection
+                    )!
+
+                    const relatedResource = resources.find(
+                        r => r.data.name === field.relatedProperty.type
+                    )!
+
+                    await populateFromResolvedNodes(
+                        manager,
+                        relatedResource,
+                        fieldTypes[
+                            Object.keys(
+                                fieldNode[manyToOneSelection].fieldsByTypeName
+                            )[0]
+                        ],
+                        data.map(d => d[field.databaseField])
+                    )
+                }
+            }
+
+            for (const manyToManySelection of manyToManySelections) {
+                const fieldTypes =
+                    fieldNode[manyToManySelection].fieldsByTypeName
+
+                if (Object.keys(fieldTypes).length > 0) {
+                    const field = relatedManyToManyFields.find(
+                        f => f.databaseField === manyToManySelection
+                    )!
+
+                    const relatedResource = resources.find(
+                        r => r.data.name === field.relatedProperty.type
+                    )!
+
+                    await populateFromResolvedNodes(
+                        manager,
+                        relatedResource,
+                        fieldTypes[
+                            Object.keys(
+                                fieldNode[manyToManySelection].fieldsByTypeName
+                            )[0]
+                        ],
+                        data
+                            .map(d => d[field.databaseField])
+                            .reduce((acc, d) => [...acc, ...d], [])
+                    )
+                }
+            }
+
+            for (const oneToManySelection of oneToManySelections) {
+                const fieldTypes =
+                    fieldNode[oneToManySelection].fieldsByTypeName
+
+                if (Object.keys(fieldTypes).length > 0) {
+                    const field = relatedOneToManyFields.find(
+                        f => f.databaseField === oneToManySelection
+                    )!
+
+                    const relatedResource = resources.find(
+                        r => r.data.name === field.relatedProperty.type
+                    )!
+
+                    await populateFromResolvedNodes(
+                        manager,
+                        relatedResource,
+                        fieldTypes[
+                            Object.keys(
+                                fieldNode[oneToManySelection].fieldsByTypeName
+                            )[0]
+                        ],
+                        data
+                            .map(d => d[field.databaseField])
+                            .reduce((acc, d) => [...acc, ...d], [])
+                    )
+                }
+            }
+        }
+
+        return data
+    }
+
+    resources.forEach(resource => {
+        resolversList.push(
+            graphQlQuery(`Fetch ${resource.data.snakeCaseNamePlural}`)
+                .path(resource.data.snakeCaseNamePlural)
+                .query()
+                .internal()
+                .resource(resource)
+                .handle(async (_, args, ctx, info) => {
+                    const data: any[] = await ctx.manager.find(
+                        resource.data.pascalCaseName,
+                        parseWhereArgumentsToWhereQuery(args.where),
+                        getFindOptionsFromArgs(args)
+                    )
+
+                    await populateFromResolvedNodes(
+                        ctx.manager,
+                        resource,
+                        getParsedInfo(info),
+                        data
+                    )
+
+                    return data
+                })
+        )
+
+        resolversList.push(
+            graphQlQuery(`Fetch single ${resource.data.snakeCaseName}`)
+                .path(resource.data.snakeCaseName)
+                .query()
+                .internal()
+                .resource(resource)
+                .handle(async (_, args, ctx, info) => {
+                    const data: any = await ctx.manager.findOneOrFail(
+                        resource.data.pascalCaseName,
+                        {
+                            id: args.id
+                        }
+                    )
+
+                    await populateFromResolvedNodes(
+                        ctx.manager,
+                        resource,
+                        getParsedInfo(info),
+                        [data]
+                    )
+
+                    return data
+                })
+        )
+
+        resolversList.push(
+            graphQlQuery(`Insert single ${resource.data.snakeCaseName}`)
+                .path(`insert_${resource.data.snakeCaseName}`)
+                .mutation()
+                .internal()
+                .resource(resource)
+                .handle(async (_, args, ctx, info) => {
+                    const data = ctx.manager.create(
+                        resource.data.pascalCaseName,
+                        args.object
+                    )
+
+                    await ctx.manager.persistAndFlush(data)
+
+                    await populateFromResolvedNodes(
+                        ctx.manager,
+                        resource,
+                        getParsedInfo(info),
+                        [data]
+                    )
+
+                    subscriptionsEnabled &&
+                        ctx.pubsub.publish(
+                            `${resource.data.snakeCaseName}_inserted`,
+                            {
+                                [`${resource.data.snakeCaseName}_inserted`]: data
+                            }
+                        )
+
+                    return data
+                })
+        )
+
+        resolversList.push(
+            graphQlQuery(`Insert multiple ${resource.data.snakeCaseNamePlural}`)
+                .path(`insert_${resource.data.snakeCaseNamePlural}`)
+                .mutation()
+                .internal()
+                .resource(resource)
+                .handle(async (_, args, ctx, info) => {
+                    const data: any[] = args.objects.map((object: any) =>
+                        ctx.manager.create(resource.data.pascalCaseName, object)
+                    )
+
+                    await ctx.manager.persistAndFlush(data)
+
+                    await ctx.manager.persistAndFlush(data)
+
+                    await populateFromResolvedNodes(
+                        ctx.manager,
+                        resource,
+                        getParsedInfo(info),
+                        data
+                    )
+
+                    subscriptionsEnabled &&
+                        data.forEach(d => {
+                            ctx.pubsub.publish(
+                                `${resource.data.snakeCaseName}_inserted`,
+                                {
+                                    [`${resource.data.snakeCaseName}_inserted`]: d
+                                }
+                            )
+                        })
+
+                    return data
+                })
+        )
+
+        resolversList.push(
+            graphQlQuery(`Update single ${resource.data.snakeCaseName}`)
+                .path(`update_${resource.data.snakeCaseName}`)
+                .mutation()
+                .internal()
+                .resource(resource)
+                .handle(async (_, args, ctx, info) => {
+                    const data: any = await ctx.manager
+                        .getRepository<any>(resource.data.pascalCaseName)
+                        .findOneOrFail(args.id)
+
+                    ctx.manager.assign(data, args.object)
+
+                    await ctx.manager.persistAndFlush(data)
+
+                    await populateFromResolvedNodes(
+                        ctx.manager,
+                        resource,
+                        getParsedInfo(info),
+                        [data]
+                    )
+
+                    subscriptionsEnabled &&
+                        ctx.pubsub.publish(
+                            `${resource.data.snakeCaseName}_updated`,
+                            {
+                                [`${resource.data.snakeCaseName}_updated`]: data
+                            }
+                        )
+
+                    return data
+                })
+        )
+
+        resolversList.push(
+            graphQlQuery(`Update multiple ${resource.data.snakeCaseNamePlural}`)
+                .path(`update_${resource.data.snakeCaseNamePlural}`)
+                .mutation()
+                .internal()
+                .resource(resource)
+                .handle(async (_, args, ctx, info) => {
+                    const data = await ctx.manager.find(
+                        resource.data.pascalCaseName,
+                        parseWhereArgumentsToWhereQuery(args.where)
+                    )
+
+                    data.forEach(d => ctx.manager.assign(d, args.object))
+
+                    await ctx.manager.persistAndFlush(data)
+
+                    await populateFromResolvedNodes(
+                        ctx.manager,
+                        resource,
+                        getParsedInfo(info),
+                        data
+                    )
+
+                    subscriptionsEnabled &&
+                        data.forEach(d => {
+                            ctx.pubsub.publish(
+                                `${resource.data.snakeCaseName}_updated`,
+                                {
+                                    [`${resource.data.snakeCaseName}_updated`]: d
+                                }
+                            )
+                        })
+
+                    return data
+                })
+        )
+
+        resolversList.push(
+            graphQlQuery(`Delete single ${resource.data.snakeCaseName}`)
+                .path(`delete_${resource.data.snakeCaseName}`)
+                .mutation()
+                .internal()
+                .resource(resource)
+                .handle(async (_, args, ctx, info) => {
+                    const data: any = await ctx.manager
+                        .getRepository<any>(resource.data.pascalCaseName)
+                        .findOneOrFail(args.id)
+
+                    await populateFromResolvedNodes(
+                        ctx.manager,
+                        resource,
+                        getParsedInfo(info),
+                        [data]
+                    )
+
+                    await ctx.manager.removeAndFlush(data)
+
+                    subscriptionsEnabled &&
+                        ctx.pubsub.publish(
+                            `${resource.data.snakeCaseName}_deleted`,
+                            {
+                                [`${resource.data.snakeCaseName}_deleted`]: data
+                            }
+                        )
+
+                    return data
+                })
+        )
+
+        resolversList.push(
+            graphQlQuery(`Delete multiple ${resource.data.snakeCaseNamePlural}`)
+                .path(`delete_${resource.data.snakeCaseNamePlural}`)
+                .mutation()
+                .internal()
+                .resource(resource)
+                .handle(async (_, args, ctx, info) => {
+                    const data = await ctx.manager.find(
+                        resource.data.pascalCaseName,
+                        parseWhereArgumentsToWhereQuery(args.where)
+                    )
+
+                    await populateFromResolvedNodes(
+                        ctx.manager,
+                        resource,
+                        getParsedInfo(info),
+                        data
+                    )
+
+                    await ctx.manager.removeAndFlush(data)
+
+                    subscriptionsEnabled &&
+                        data.forEach(d => {
+                            ctx.pubsub.publish(
+                                `${resource.data.snakeCaseName}_deleted`,
+                                {
+                                    [`${resource.data.snakeCaseName}_deleted`]: d
+                                }
+                            )
+                        })
+
+                    return data
+                })
+        )
+
+        if (subscriptionsEnabled) {
+            resolversList.push(
+                graphQlQuery(
+                    `${resource.data.snakeCaseName} inserted subscription`
+                )
+                    .subscription()
+                    .path(`${resource.data.snakeCaseName}_inserted`)
+                    .resource(resource)
+                    .handle((_, args, ctx, info) =>
+                        ctx.pubsub.asyncIterator([
+                            `${resource.data.snakeCaseName}_inserted`
+                        ])
+                    )
+            )
+
+            resolversList.push(
+                graphQlQuery(
+                    `${resource.data.snakeCaseName} updated subscription`
+                )
+                    .subscription()
+                    .path(`${resource.data.snakeCaseName}_updated`)
+                    .resource(resource)
+                    .handle((_, args, ctx, info) =>
+                        ctx.pubsub.asyncIterator([
+                            `${resource.data.snakeCaseName}_updated`
+                        ])
+                    )
+            )
+
+            resolversList.push(
+                graphQlQuery(
+                    `${resource.data.snakeCaseName} deleted subscription`
+                )
+                    .subscription()
+                    .path(`${resource.data.snakeCaseName}_deleted`)
+                    .resource(resource)
+                    .handle((_, args, ctx, info) =>
+                        ctx.pubsub.asyncIterator([
+                            `${resource.data.snakeCaseName}_deleted`
+                        ])
+                    )
+            )
+        }
+    })
+
+    return resolversList
+}
+
+export const getFindOptionsFromArgs = (args: any) => {
+    let findOptions: any = {}
+
+    if (!args) {
+        return {}
+    }
+
+    if (args.limit) {
+        findOptions.limit = args.limit
+    }
+
+    if (args.offset) {
+        findOptions.limit = args.offset
+    }
+
+    return findOptions
+}
+
+const getParsedInfo = (ql: any) => {
+    const parsedInfo = parseResolveInfo(ql, {
+        keepRoot: false
+    }) as any
+
+    return parsedInfo.fieldsByTypeName[
+        Object.keys(parsedInfo.fieldsByTypeName)[0]
+    ]
+}
+
+export const parseWhereArgumentsToWhereQuery = (whereArgument: any) => {
+    if (!whereArgument) {
+        return {}
+    }
+    let whereArgumentString = JSON.stringify(whereArgument)
+
+    allOperators.forEach(operator => {
+        whereArgumentString = whereArgumentString.replace(
+            `"${operator}"`,
+            `"$${operator.split('_')[1]}"`
+        )
+    })
+
+    return JSON.parse(whereArgumentString)
+}
+
+export const filterOperators: FilterOperators[] = [
+    '_eq',
+    '_ne',
+    '_in',
+    '_nin',
+    '_gt',
+    '_gte',
+    '_lt',
+    '_lte',
+    '_like',
+    '_re',
+    '_ilike',
+    '_overlap',
+    '_contains',
+    '_contained'
+]
+
+export const topLevelOperators: FilterOperators[] = ['_and', '_or', '_not']
+
+export const allOperators = filterOperators.concat(topLevelOperators)
+
+export const authorizeResolver = async (
+    ctx: GraphQLPluginContext,
+    query: GraphQlQueryContract
+) => {
+    const authorized = await Promise.all(
+        query.config.authorize.map(fn => fn(ctx))
+    )
+
+    if (
+        authorized.filter(result => result).length !==
+        query.config.authorize.length
+    ) {
+        throw ctx.forbiddenError('Unauthorized.')
+    }
+}

--- a/packages/graphql/src/Subscriptions.ts
+++ b/packages/graphql/src/Subscriptions.ts
@@ -1,0 +1,26 @@
+import { PubSub } from 'apollo-server-express'
+import { ResourceContract } from '@tensei/common'
+
+export const defineCreateSubscriptionsForResource = (
+    resource: ResourceContract
+) => {
+    return `
+    ${resource.data.snakeCaseName}_inserted(filter: JSONObject): ${resource.data.snakeCaseName}!    
+`
+}
+
+export const defineUpdateSubscriptionsForResource = (
+    resource: ResourceContract
+) => {
+    return `
+    ${resource.data.snakeCaseName}_updated(filter: JSONObject): ${resource.data.snakeCaseName}!    
+`
+}
+
+export const defineDeleteSubscriptionsForResource = (
+    resource: ResourceContract
+) => {
+    return `
+    ${resource.data.snakeCaseName}_deleted(filter: JSONObject): ${resource.data.snakeCaseName}!    
+`
+}

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -47,6 +47,8 @@ class Graphql {
 
     private getMiddlewareOptions: GetMiddlewareOptions = {}
 
+    private pubsub: PubSub | undefined
+
     schemaString: string = `
     scalar JSON
     scalar JSONObject
@@ -466,7 +468,8 @@ input id_where_query {
         return this
     }
 
-    subscriptions() {
+    subscriptions(pubsub?: PubSub) {
+        this.pubsub = pubsub || new PubSub()
         this.subscriptionsEnabled = true
 
         return this
@@ -658,12 +661,6 @@ input id_where_query {
                     resolvers
                 })
 
-                let pubsub: PubSub
-
-                if (this.subscriptionsEnabled) {
-                    pubsub = new PubSub()
-                }
-
                 const graphQlServer = new ApolloServer({
                     schema: applyMiddleware(
                         schema,
@@ -679,7 +676,7 @@ input id_where_query {
                     context: ctx => ({
                         ...ctx,
                         ...config,
-                        pubsub,
+                        pubsub: this.pubsub,
                         manager: manager!.fork()
                     })
                 })

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,94 +1,42 @@
 import { applyMiddleware } from 'graphql-middleware'
-import { parseResolveInfo } from 'graphql-parse-resolve-info'
+import GraphQLJSON, { GraphQLJSONObject } from 'graphql-type-json'
 import {
-    ApolloServer,
     gql,
+    ApolloServer,
     Config as ApolloConfig,
     makeExecutableSchema,
     AuthenticationError,
     ForbiddenError,
     ValidationError,
     UserInputError,
-    GetMiddlewareOptions
+    GetMiddlewareOptions,
+    PubSub,
+    withFilter
 } from 'apollo-server-express'
 import {
     plugin,
     FieldContract,
     ResourceContract,
     PluginSetupConfig,
-    FilterOperators,
     GraphQLPluginExtension,
     Resolvers,
-    graphQlQuery,
     GraphQlMiddleware,
     GraphQlQueryContract
 } from '@tensei/common'
-import { EntityManager, ReferenceType } from '@mikro-orm/core'
+import { ReferenceType } from '@mikro-orm/core'
 
-const filterOperators: FilterOperators[] = [
-    '_eq',
-    '_ne',
-    '_in',
-    '_nin',
-    '_gt',
-    '_gte',
-    '_lt',
-    '_lte',
-    '_like',
-    '_re',
-    '_ilike',
-    '_overlap',
-    '_contains',
-    '_contained'
-]
+import {
+    topLevelOperators,
+    filterOperators,
+    getResolvers,
+    authorizeResolver
+} from './Resolvers'
 
-const topLevelOperators: FilterOperators[] = ['_and', '_or', '_not']
-
-const allOperators = filterOperators.concat(topLevelOperators)
-
-const parseWhereArgumentsToWhereQuery = (whereArgument: any) => {
-    if (!whereArgument) {
-        return {}
-    }
-    let whereArgumentString = JSON.stringify(whereArgument)
-
-    allOperators.forEach(operator => {
-        whereArgumentString = whereArgumentString.replace(
-            `"${operator}"`,
-            `"$${operator.split('_')[1]}"`
-        )
-    })
-
-    return JSON.parse(whereArgumentString)
-}
-
-const getParsedInfo = (ql: any) => {
-    const parsedInfo = parseResolveInfo(ql, {
-        keepRoot: false
-    }) as any
-
-    return parsedInfo.fieldsByTypeName[
-        Object.keys(parsedInfo.fieldsByTypeName)[0]
-    ]
-}
-
-const getFindOptionsFromArgs = (args: any) => {
-    let findOptions: any = {}
-
-    if (!args) {
-        return {}
-    }
-
-    if (args.limit) {
-        findOptions.limit = args.limit
-    }
-
-    if (args.offset) {
-        findOptions.limit = args.offset
-    }
-
-    return findOptions
-}
+import {
+    defineCreateSubscriptionsForResource,
+    defineDeleteSubscriptionsForResource,
+    defineUpdateSubscriptionsForResource
+} from './Subscriptions'
 
 type OmittedApolloConfig = Omit<ApolloConfig, 'typeDefs' | 'resolvers'>
 
@@ -99,7 +47,12 @@ class Graphql {
 
     private getMiddlewareOptions: GetMiddlewareOptions = {}
 
-    schemaString: string = ''
+    schemaString: string = `
+    scalar JSON
+    scalar JSONObject
+    `
+
+    private subscriptionsEnabled = false
 
     private getGraphqlFieldDefinitionForCreateInput = (
         field: FieldContract,
@@ -230,7 +183,11 @@ class Graphql {
         }`
     }
 
-    getWhereQueryFieldType(field: FieldContract, config: PluginSetupConfig) {
+    getWhereQueryFieldType(
+        field: FieldContract,
+        config: PluginSetupConfig,
+        filter = false
+    ) {
         if (field.property.type === 'boolean') {
             // return 'boolean_where_query'
         }
@@ -247,7 +204,9 @@ class Graphql {
                     resource.data.pascalCaseName === field.relatedProperty.type
             )
 
-            return `${relatedResource?.data.snakeCaseName}_where_query`
+            return `${relatedResource?.data.snakeCaseName}_${
+                filter ? 'subscription_filter' : 'where_query'
+            }`
         }
 
         if (field.property.primary) {
@@ -279,6 +238,16 @@ ${resource.data.fields.map(
     field =>
         `${field.databaseField}: ${this.getWhereQueryFieldType(field, config)}`
 )}
+}
+input ${resource.data.snakeCaseName}_subscription_filter {
+    ${resource.data.fields.map(
+        field =>
+            `${field.databaseField}: ${this.getWhereQueryFieldType(
+                field,
+                config,
+                true
+            )}`
+    )}
 }
 `
     }
@@ -385,6 +354,19 @@ ${this.getWhereQueryForResource(resource, config)}
         )}
 }
 `
+        this.schemaString = `${
+            this.schemaString
+        }type Subscription {${resources.map(
+            resource => `${defineCreateSubscriptionsForResource(resource)}`
+        )}
+${resources.map(
+    resource => `${defineUpdateSubscriptionsForResource(resource)}`
+)}
+${resources.map(
+    resource => `${defineDeleteSubscriptionsForResource(resource)}`
+)}
+}`
+
         this.schemaString = `${this.schemaString}type Mutation {${resources.map(
             resource => {
                 return `${this.defineCreateMutationForResource(
@@ -478,557 +460,14 @@ input id_where_query {
         return 'id'
     }
 
-    private getResolvers(resources: ResourceContract[]) {
-        const resolversList: GraphQlQueryContract[] = []
-
-        const populateFromResolvedNodes = async (
-            manager: EntityManager,
-            resource: ResourceContract,
-            fieldNode: any,
-            data: any[]
-        ) => {
-            if (!data.length) return
-
-            const relationshipFields = resource.data.fields.filter(
-                f => f.relatedProperty.reference
-            )
-
-            const relatedManyToOneFields = relationshipFields.filter(
-                field =>
-                    field.relatedProperty.reference ===
-                    ReferenceType.MANY_TO_ONE
-            )
-            const relatedManyToManyFields = relationshipFields.filter(
-                field =>
-                    field.relatedProperty.reference ===
-                    ReferenceType.MANY_TO_MANY
-            )
-            const relatedOneToManyFields = relationshipFields.filter(
-                field =>
-                    field.relatedProperty.reference ===
-                    ReferenceType.ONE_TO_MANY
-            )
-            const relatedOneToOneFields = relationshipFields.filter(
-                field =>
-                    field.relatedProperty.reference === ReferenceType.ONE_TO_ONE
-            )
-
-            const relatedManyToOneDatabaseFieldNames = relatedManyToOneFields.map(
-                field => field.databaseField
-            )
-            const relatedManyToManyDatabaseFieldNames = relatedManyToManyFields.map(
-                field => field.databaseField
-            )
-            const relatedOneToManyDatabaseFieldNames = relatedOneToManyFields.map(
-                field => field.databaseField
-            )
-            const relatedOneToOneDatabaseFieldNames = relatedOneToOneFields.map(
-                field => field.databaseField
-            )
-
-            if (Object.keys(fieldNode).length > 0) {
-                const countSelections = Object.keys(
-                    fieldNode
-                ).filter((selection: string) => selection.match(/__count/))
-                const countSelectionNames: string[] = countSelections.map(
-                    (selection: string) => selection.split('__')[0]
-                )
-
-                const manyToOneSelections = Object.keys(
-                    fieldNode
-                ).filter((selection: string) =>
-                    relatedManyToOneDatabaseFieldNames.includes(selection)
-                )
-                const manyToManySelections = Object.keys(
-                    fieldNode
-                ).filter((selection: string) =>
-                    relatedManyToManyDatabaseFieldNames.includes(selection)
-                )
-                const oneToManySelections = Object.keys(
-                    fieldNode
-                ).filter((selection: string) =>
-                    relatedOneToManyDatabaseFieldNames.includes(selection)
-                )
-
-                await Promise.all([
-                    Promise.all(
-                        manyToOneSelections.map((selection: string) =>
-                            manager.populate(data, selection)
-                        )
-                    ),
-                    Promise.all(
-                        manyToManySelections.map((selection: string) =>
-                            (async () => {
-                                const field = relatedManyToManyFields.find(
-                                    _ => _.databaseField === selection
-                                )
-
-                                if (
-                                    !fieldNode[selection].args.where &&
-                                    !fieldNode[selection].args.limit &&
-                                    !fieldNode[selection].args.offset
-                                ) {
-                                    await manager.populate(data, selection)
-
-                                    return
-                                }
-
-                                await Promise.all(
-                                    data.map(async item => {
-                                        const relatedData: any = await manager.find(
-                                            field?.relatedProperty.type!,
-                                            {
-                                                [resource.data
-                                                    .snakeCaseNamePlural]: {
-                                                    id: {
-                                                        $in: [item.id]
-                                                    }
-                                                },
-                                                ...parseWhereArgumentsToWhereQuery(
-                                                    fieldNode[selection].args
-                                                        .where
-                                                )
-                                            },
-                                            getFindOptionsFromArgs(
-                                                fieldNode[selection].args
-                                            )
-                                        )
-
-                                        item[
-                                            field?.databaseField!
-                                        ] = relatedData
-                                    })
-                                )
-                            })()
-                        )
-                    ),
-                    Promise.all(
-                        oneToManySelections.map((selection: string) =>
-                            (async () => {
-                                if (
-                                    !fieldNode[selection].args.where &&
-                                    !fieldNode[selection].args.limit &&
-                                    !fieldNode[selection].args.offset
-                                ) {
-                                    await manager.populate(data, selection)
-
-                                    return
-                                }
-
-                                const field = relatedOneToManyFields.find(
-                                    _ => _.databaseField === selection
-                                )
-
-                                await Promise.all(
-                                    data.map(async item => {
-                                        const relatedData: any = await manager.find(
-                                            field?.relatedProperty.type!,
-                                            {
-                                                [resource.data.snakeCaseName]:
-                                                    item.id,
-                                                ...parseWhereArgumentsToWhereQuery(
-                                                    fieldNode[selection].args
-                                                        .where
-                                                )
-                                            },
-                                            getFindOptionsFromArgs(
-                                                fieldNode[selection].args
-                                            )
-                                        )
-
-                                        item[
-                                            field?.databaseField!
-                                        ] = relatedData
-                                    })
-                                )
-                            })()
-                        )
-                    ),
-                    Promise.all(
-                        countSelectionNames.map(async selection => {
-                            if (
-                                relatedManyToManyDatabaseFieldNames.includes(
-                                    selection
-                                )
-                            ) {
-                                const field = relatedManyToManyFields.find(
-                                    _ => _.databaseField === selection
-                                )
-
-                                await Promise.all(
-                                    data.map(async item => {
-                                        const count = await manager.count(
-                                            field?.relatedProperty.type!,
-                                            {
-                                                [resource.data
-                                                    .snakeCaseNamePlural]: {
-                                                    id: {
-                                                        $in: [item.id]
-                                                    }
-                                                },
-                                                ...parseWhereArgumentsToWhereQuery(
-                                                    fieldNode[
-                                                        `${selection}__count`
-                                                    ].args.where
-                                                )
-                                            }
-                                        )
-
-                                        item[
-                                            `${field?.databaseField}__count`
-                                        ] = count
-                                    })
-                                )
-                            }
-
-                            if (
-                                relatedOneToManyDatabaseFieldNames.includes(
-                                    selection
-                                )
-                            ) {
-                                const field = relatedOneToManyFields.find(
-                                    _ => _.databaseField === selection
-                                )
-
-                                const uniqueKeys = Array.from(
-                                    new Set(data.map(_ => _.id))
-                                )
-
-                                const counts: any[] = await Promise.all(
-                                    uniqueKeys.map(async key =>
-                                        manager.count(
-                                            field?.relatedProperty.type!,
-                                            {
-                                                [resource.data
-                                                    .snakeCaseName]: key,
-                                                ...parseWhereArgumentsToWhereQuery(
-                                                    fieldNode[
-                                                        `${selection}__count`
-                                                    ].args.where
-                                                )
-                                            }
-                                        )
-                                    )
-                                )
-
-                                data.forEach(item => {
-                                    const index = uniqueKeys.indexOf(item.id)
-
-                                    item[`${field?.databaseField}__count`] =
-                                        counts[index]
-                                })
-                            }
-                        })
-                    )
-                ])
-
-                for (const manyToOneSelection of manyToOneSelections) {
-                    const fieldTypes =
-                        fieldNode[manyToOneSelection].fieldsByTypeName
-
-                    if (Object.keys(fieldTypes).length > 0) {
-                        const field = relatedManyToOneFields.find(
-                            f => f.databaseField === manyToOneSelection
-                        )!
-
-                        const relatedResource = resources.find(
-                            r => r.data.name === field.relatedProperty.type
-                        )!
-
-                        await populateFromResolvedNodes(
-                            manager,
-                            relatedResource,
-                            fieldTypes[
-                                Object.keys(
-                                    fieldNode[manyToOneSelection]
-                                        .fieldsByTypeName
-                                )[0]
-                            ],
-                            data.map(d => d[field.databaseField])
-                        )
-                    }
-                }
-
-                for (const manyToManySelection of manyToManySelections) {
-                    const fieldTypes =
-                        fieldNode[manyToManySelection].fieldsByTypeName
-
-                    if (Object.keys(fieldTypes).length > 0) {
-                        const field = relatedManyToManyFields.find(
-                            f => f.databaseField === manyToManySelection
-                        )!
-
-                        const relatedResource = resources.find(
-                            r => r.data.name === field.relatedProperty.type
-                        )!
-
-                        await populateFromResolvedNodes(
-                            manager,
-                            relatedResource,
-                            fieldTypes[
-                                Object.keys(
-                                    fieldNode[manyToManySelection]
-                                        .fieldsByTypeName
-                                )[0]
-                            ],
-                            data
-                                .map(d => d[field.databaseField])
-                                .reduce((acc, d) => [...acc, ...d], [])
-                        )
-                    }
-                }
-
-                for (const oneToManySelection of oneToManySelections) {
-                    const fieldTypes =
-                        fieldNode[oneToManySelection].fieldsByTypeName
-
-                    if (Object.keys(fieldTypes).length > 0) {
-                        const field = relatedOneToManyFields.find(
-                            f => f.databaseField === oneToManySelection
-                        )!
-
-                        const relatedResource = resources.find(
-                            r => r.data.name === field.relatedProperty.type
-                        )!
-
-                        await populateFromResolvedNodes(
-                            manager,
-                            relatedResource,
-                            fieldTypes[
-                                Object.keys(
-                                    fieldNode[oneToManySelection]
-                                        .fieldsByTypeName
-                                )[0]
-                            ],
-                            data
-                                .map(d => d[field.databaseField])
-                                .reduce((acc, d) => [...acc, ...d], [])
-                        )
-                    }
-                }
-            }
-
-            return data
-        }
-
-        resources.forEach(resource => {
-            resolversList.push(
-                graphQlQuery(`Fetch ${resource.data.snakeCaseNamePlural}`)
-                    .path(resource.data.snakeCaseNamePlural)
-                    .query()
-                    .internal()
-                    .resource(resource)
-                    .handle(async (_, args, ctx, info) => {
-                        const data: any[] = await ctx.manager.find(
-                            resource.data.pascalCaseName,
-                            parseWhereArgumentsToWhereQuery(args.where),
-                            getFindOptionsFromArgs(args)
-                        )
-
-                        await populateFromResolvedNodes(
-                            ctx.manager,
-                            resource,
-                            getParsedInfo(info),
-                            data
-                        )
-
-                        return data
-                    })
-            )
-
-            resolversList.push(
-                graphQlQuery(`Fetch single ${resource.data.snakeCaseName}`)
-                    .path(resource.data.snakeCaseName)
-                    .query()
-                    .internal()
-                    .resource(resource)
-                    .handle(async (_, args, ctx, info) => {
-                        const data: any = await ctx.manager.findOneOrFail(
-                            resource.data.pascalCaseName,
-                            {
-                                id: args.id
-                            }
-                        )
-
-                        await populateFromResolvedNodes(
-                            ctx.manager,
-                            resource,
-                            getParsedInfo(info),
-                            [data]
-                        )
-
-                        return data
-                    })
-            )
-
-            resolversList.push(
-                graphQlQuery(`Insert single ${resource.data.snakeCaseName}`)
-                    .path(`insert_${resource.data.snakeCaseName}`)
-                    .mutation()
-                    .internal()
-                    .resource(resource)
-                    .handle(async (_, args, ctx, info) => {
-                        const data = ctx.manager.create(
-                            resource.data.pascalCaseName,
-                            args.object
-                        )
-
-                        await ctx.manager.persistAndFlush(data)
-
-                        await populateFromResolvedNodes(
-                            ctx.manager,
-                            resource,
-                            getParsedInfo(info),
-                            [data]
-                        )
-
-                        return data
-                    })
-            )
-
-            resolversList.push(
-                graphQlQuery(
-                    `Insert multiple ${resource.data.snakeCaseNamePlural}`
-                )
-                    .path(`insert_${resource.data.snakeCaseNamePlural}`)
-                    .mutation()
-                    .internal()
-                    .resource(resource)
-                    .handle(async (_, args, ctx, info) => {
-                        const data: any[] = args.objects.map((object: any) =>
-                            ctx.manager.create(
-                                resource.data.pascalCaseName,
-                                object
-                            )
-                        )
-
-                        await ctx.manager.persistAndFlush(data)
-
-                        await ctx.manager.persistAndFlush(data)
-
-                        await populateFromResolvedNodes(
-                            ctx.manager,
-                            resource,
-                            getParsedInfo(info),
-                            data
-                        )
-
-                        return data
-                    })
-            )
-
-            resolversList.push(
-                graphQlQuery(`Update single ${resource.data.snakeCaseName}`)
-                    .path(`update_${resource.data.snakeCaseName}`)
-                    .mutation()
-                    .internal()
-                    .resource(resource)
-                    .handle(async (_, args, ctx, info) => {
-                        const data: any = await ctx.manager
-                            .getRepository<any>(resource.data.pascalCaseName)
-                            .findOneOrFail(args.id)
-
-                        ctx.manager.assign(data, args.object)
-
-                        await ctx.manager.persistAndFlush(data)
-
-                        await populateFromResolvedNodes(
-                            ctx.manager,
-                            resource,
-                            getParsedInfo(info),
-                            [data]
-                        )
-
-                        return data
-                    })
-            )
-
-            resolversList.push(
-                graphQlQuery(
-                    `Update multiple ${resource.data.snakeCaseNamePlural}`
-                )
-                    .path(`update_${resource.data.snakeCaseNamePlural}`)
-                    .mutation()
-                    .internal()
-                    .resource(resource)
-                    .handle(async (_, args, ctx, info) => {
-                        const data = await ctx.manager.find(
-                            resource.data.pascalCaseName,
-                            parseWhereArgumentsToWhereQuery(args.where)
-                        )
-
-                        data.forEach(d => ctx.manager.assign(d, args.object))
-
-                        await ctx.manager.persistAndFlush(data)
-
-                        await populateFromResolvedNodes(
-                            ctx.manager,
-                            resource,
-                            getParsedInfo(info),
-                            data
-                        )
-
-                        return data
-                    })
-            )
-
-            resolversList.push(
-                graphQlQuery(`Delete single ${resource.data.snakeCaseName}`)
-                    .path(`delete_${resource.data.snakeCaseName}`)
-                    .mutation()
-                    .internal()
-                    .resource(resource)
-                    .handle(async (_, args, ctx, info) => {
-                        const data: any = await ctx.manager
-                            .getRepository<any>(resource.data.pascalCaseName)
-                            .findOneOrFail(args.id)
-
-                        await populateFromResolvedNodes(
-                            ctx.manager,
-                            resource,
-                            getParsedInfo(info),
-                            [data]
-                        )
-
-                        await ctx.manager.removeAndFlush(data)
-
-                        return data
-                    })
-            )
-
-            resolversList.push(
-                graphQlQuery(
-                    `Delete multiple ${resource.data.snakeCaseNamePlural}`
-                )
-                    .path(`delete_${resource.data.snakeCaseNamePlural}`)
-                    .mutation()
-                    .internal()
-                    .resource(resource)
-                    .handle(async (_, args, ctx, info) => {
-                        const data = await ctx.manager.find(
-                            resource.data.pascalCaseName,
-                            parseWhereArgumentsToWhereQuery(args.where)
-                        )
-
-                        await populateFromResolvedNodes(
-                            ctx.manager,
-                            resource,
-                            getParsedInfo(info),
-                            data
-                        )
-
-                        await ctx.manager.removeAndFlush(data)
-
-                        return data
-                    })
-            )
-        })
-
-        return resolversList
-    }
-
     extensions(extensions: GraphQLPluginExtension[]) {
         this.pluginExtensions = extensions
+
+        return this
+    }
+
+    subscriptions() {
+        this.subscriptionsEnabled = true
 
         return this
     }
@@ -1048,7 +487,8 @@ input id_where_query {
     getResolversFromGraphqlQueries(queries: GraphQlQueryContract[]) {
         const resolvers: any = {
             Query: {},
-            Mutation: {}
+            Mutation: {},
+            Subscription: {}
         }
 
         queries.forEach(query => {
@@ -1058,6 +498,29 @@ input id_where_query {
 
             if (query.config.type === 'QUERY') {
                 resolvers.Query[query.config.path] = query.config.handler
+            }
+
+            if (query.config.type === 'SUBSCRIPTION') {
+                resolvers.Subscription[query.config.path] = {
+                    subscribe: async (
+                        _: any,
+                        args: any,
+                        ctx: any,
+                        info: any
+                    ) => {
+                        for (const middleware of query.config.middleware) {
+                            await middleware(_, args, ctx, info)
+                        }
+
+                        await authorizeResolver(ctx, query)
+
+                        return withFilter(
+                            () =>
+                                query.config.handler(_, args, ctx, info) as any,
+                            query.config.filter
+                        )(_, args, ctx, info)
+                    }
+                }
             }
         })
 
@@ -1083,12 +546,17 @@ input id_where_query {
 
                 this.setupResourceGraphqlTypes(exposedResources, config)
 
-                extendGraphQlQueries(this.getResolvers(exposedResources))
+                extendGraphQlQueries(
+                    getResolvers(exposedResources, {
+                        subscriptionsEnabled: this.subscriptionsEnabled
+                    })
+                )
 
                 graphQlMiddleware.unshift(graphQlQueries => {
                     const middlewareHandlers: Resolvers = {
                         Query: {},
-                        Mutation: {}
+                        Mutation: {},
+                        Subscription: {}
                     }
 
                     const mapArgsToBody: GraphQlMiddleware = async (
@@ -1179,14 +647,22 @@ input id_where_query {
                 } = config
                 const typeDefs = [gql(this.schemaString), ...graphQlTypeDefs]
 
-                const resolvers = this.getResolversFromGraphqlQueries(
-                    graphQlQueries
-                )
+                const resolvers = {
+                    ...this.getResolversFromGraphqlQueries(graphQlQueries),
+                    JSON: GraphQLJSON,
+                    JSONObject: GraphQLJSONObject
+                }
 
                 const schema = makeExecutableSchema({
                     typeDefs,
                     resolvers
                 })
+
+                let pubsub: PubSub
+
+                if (this.subscriptionsEnabled) {
+                    pubsub = new PubSub()
+                }
 
                 const graphQlServer = new ApolloServer({
                     schema: applyMiddleware(
@@ -1203,6 +679,7 @@ input id_where_query {
                     context: ctx => ({
                         ...ctx,
                         ...config,
+                        pubsub,
                         manager: manager!.fork()
                     })
                 })
@@ -1211,6 +688,10 @@ input id_where_query {
                     app,
                     ...this.getMiddlewareOptions
                 })
+
+                if (this.subscriptionsEnabled) {
+                    graphQlServer.installSubscriptionHandlers(config.server)
+                }
             })
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,6 +4915,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+cluster-key-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -5893,7 +5898,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-denque@^1.4.1:
+denque@^1.1.0, denque@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
   integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
@@ -7545,6 +7550,15 @@ graphql-playground-middleware-express@^1.7.18:
   dependencies:
     graphql-playground-html "^1.6.29"
 
+graphql-redis-subscriptions@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/graphql-redis-subscriptions/-/graphql-redis-subscriptions-2.3.1.tgz#53d67d157f9c8c48ef0c5c1902f42fe2d0b93e27"
+  integrity sha512-ztS3ZXBSoPJ8Q0/o7PG2iLO6QWq2tlJrukiBJCjgMccRv1I3lt3HmLjiH2CbDjPhpoINttZNoytQbxE0OE/UpA==
+  dependencies:
+    iterall "^1.3.0"
+  optionalDependencies:
+    ioredis "^4.17.3"
+
 graphql-subscriptions@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz#5f2fa4233eda44cf7570526adfcf3c16937aef11"
@@ -8228,6 +8242,22 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
+ioredis@^4.17.3:
+  version "4.19.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.19.2.tgz#e3eab394c653cea5aea07c0c784d8c772dce8801"
+  integrity sha512-SZSIwMrbd96b7rJvJwyTWSP6XQ0m1kAIIqBnwglJKrIJ6na7TeY4F2EV2vDY0xm/fLrUY8cEg81dR7kVFt2sKA==
+  dependencies:
+    cluster-key-slot "^1.1.0"
+    debug "^4.1.1"
+    denque "^1.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    p-map "^2.1.0"
+    redis-commands "1.6.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.0.1"
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -8772,7 +8802,7 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-iterall@^1.1.3, iterall@^1.2.1:
+iterall@^1.1.3, iterall@^1.2.1, iterall@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -10044,6 +10074,16 @@ lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.foreach@^4.5.0:
   version "4.5.0"
@@ -13098,6 +13138,23 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis-commands@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.6.0.tgz#36d4ca42ae9ed29815cdb30ad9f97982eba1ce23"
+  integrity sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
+
 reflect-metadata@0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -14096,6 +14153,11 @@ stack-utils@^2.0.2:
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+standard-as-callback@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.0.1.tgz#ed8bb25648e15831759b6023bdb87e6b60b38126"
+  integrity sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
 
 static-eval@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7568,6 +7568,11 @@ graphql-tools@^4.0.0, graphql-tools@^4.0.5:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
+graphql-type-json@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
+  integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
+
 graphql-upload@^8.0.2:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-8.1.0.tgz#6d0ab662db5677a68bfb1f2c870ab2544c14939a"


### PR DESCRIPTION
- Setup subscription query type to GraphQlQuery
- Setup subscription filter method on GraphQlQuery class
- Add subscriptions() method to enable graphql subscriptions on graphql plugin
- Setup authorization for graphql subscriptions
- Install new graphql-type-json package for adding JSON and JSONObject scalar types
- Modify GraphqlQuery handle definition to allow non promise resolvers
- Begin refactoring graphql package into separate files

BREAKING CHANGE: - GraphqlQuery handler can now return non promise values