### PR TITLE
fix(auth): fix bug where user can login even though blocked

### DIFF
--- a/examples/blog/app.js
+++ b/examples/blog/app.js
@@ -39,6 +39,7 @@ module.exports = tensei()
             .verifyEmails()
             .teams()
             .apiPath('auth')
+            .noCookies()
             .rolesAndPermissions()
             .social('github', {
                 key: process.env.GITHUB_KEY,


### PR DESCRIPTION
When refresh token compromise is detected, We block the user, but the user can still login. This PR
fixes that by adding a check during the login flow to make sure the user cannot login when blocked