### PR TITLE
Add beforeLogin & beforeRegister hooks to @tensei/auth package

### DIFF
--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -3,6 +3,7 @@ import { CookieOptions } from 'express'
 import { AnyEntity } from '@mikro-orm/core'
 import { UserRole } from '@tensei/common'
 import { ApiContext } from '@tensei/common'
+import { DataPayload } from '@tensei/common'
 
 export interface GrantConfig {
     key: string
@@ -35,6 +36,8 @@ export enum TokenTypes {
     PASSWORDLESS = 'PASSWORDLESS'
 }
 
+export type AuthHookFunction<Payload = DataPayload> =  (ctx: ApiContext, payload: Payload) => void|Promise<any>
+
 export interface AuthPluginConfig {
     fields: FieldContract[]
     userResource: string
@@ -52,18 +55,25 @@ export interface AuthPluginConfig {
         accessTokenExpiresIn: number
         refreshTokenExpiresIn: number
     }
+    beforeLogin: AuthHookFunction
+    afterLogin: AuthHookFunction
+    beforeRegister: AuthHookFunction<{
+        roles: string[]
+        email: string
+        password: string
+        email_verified_at?: string
+        email_verification_token?: string|null
+
+        [key: string]: any
+    }>
+    afterRegister: AuthHookFunction<UserEntity>
+    beforePasswordReset: AuthHookFunction
+    afterPasswordReset: AuthHookFunction
     refreshTokenHeaderName: string
     cookieOptions: Omit<CookieOptions, 'httpOnly' | 'maxAge'>
     verifyEmails?: boolean
     skipWelcomeEmail?: boolean
     twoFactorAuth: boolean
-    beforeCreateUser?: HookFunction
-    afterCreateUser?: HookFunction
-    beforeUpdateUser?: HookFunction
-    afterUpdateUser?: HookFunction
-    beforeLoginUser?: HookFunction
-    afterLoginUser?: HookFunction
-    beforeOAuthIdentityCreated?: HookFunction
     providers: {
         [key: string]: GrantConfig
     }

--- a/packages/cli/_templates/default/new/package.json.ejs.t
+++ b/packages/cli/_templates/default/new/package.json.ejs.t
@@ -21,8 +21,8 @@ to: <%= h.changeCase.param(name) %>/package.json
         "build": "yarn build:server && yarn build:client"
     },
     "devDependencies": {
-        "@tensei/common": "^0.7.9",
-        "@tensei/components": "^0.7.9",
+        "@tensei/common": "^0.7.10",
+        "@tensei/components": "^0.7.10",
         "autoprefixer": "^10.2.4",
         "cross-env": "^7.0.3",
         "laravel-mix": "^6.0.5",

--- a/packages/common/src/fields/Select.ts
+++ b/packages/common/src/fields/Select.ts
@@ -1,4 +1,5 @@
 import Field from './Field'
+import { snakeCase } from 'change-case'
 
 export interface Option {
     label: string
@@ -28,9 +29,13 @@ export class Select extends Field {
      * forms
      *
      */
-    public options(options: Array<Option>) {
-        this.selectOptions = options
-        this.property.items = options.map(option => option.value)
+    public options(options: Array<Option|string>) {
+        this.selectOptions = options.map(option => typeof option === 'string' ? ({
+            label: option,
+            value: snakeCase(option)
+        }): option)
+
+        this.property.items = this.selectOptions.map(option => option.value)
 
         return this
     }

--- a/packages/create-tensei-app/templates/default/package.json
+++ b/packages/create-tensei-app/templates/default/package.json
@@ -4,11 +4,11 @@
     "main": "index.js",
     "license": "MIT",
     "dependencies": {
-        "@tensei/auth": "^0.7.9",
-        "@tensei/cms": "^0.7.9",
-        "@tensei/core": "^0.7.9",
-        "@tensei/media": "^0.7.9",
-        "@tensei/graphql": "^0.7.9"
+        "@tensei/auth": "^0.7.10",
+        "@tensei/cms": "^0.7.10",
+        "@tensei/core": "^0.7.10",
+        "@tensei/media": "^0.7.10",
+        "@tensei/graphql": "^0.7.10"
     },
     "scripts": {
         "dev": "nodemon src/index",

--- a/packages/create-tensei-app/templates/rest/package.json
+++ b/packages/create-tensei-app/templates/rest/package.json
@@ -4,11 +4,11 @@
     "main": "index.js",
     "license": "MIT",
     "dependencies": {
-        "@tensei/auth": "^0.7.9",
-        "@tensei/cms": "^0.7.9",
-        "@tensei/core": "^0.7.9",
-        "@tensei/media": "^0.7.9",
-        "@tensei/rest": "^0.7.9"
+        "@tensei/auth": "^0.7.10",
+        "@tensei/cms": "^0.7.10",
+        "@tensei/core": "^0.7.10",
+        "@tensei/media": "^0.7.10",
+        "@tensei/rest": "^0.7.10"
     },
     "scripts": {
         "dev": "nodemon src/index",

--- a/packages/social-auth/src/index.js
+++ b/packages/social-auth/src/index.js
@@ -20,13 +20,17 @@ class SocialAuthCallbackController {
                 query.access_token || query.code || query.oauth_token
 
             const redirect = (error, code) =>
-                response.redirect(
-                    `${authConfig.providers[provider].clientCallback}${
-                        error ? `?error=${error}` : ''
-                    }${
-                        code ? `?access_token=${code}` : ''
-                    }&provider=${provider}`
-                )
+                {
+                    const clientRedirect = query.clientCallback ? query.clientCallback: authConfig.providers[provider].clientCallback
+
+                    return response.redirect(
+                        `${clientRedirect}${
+                            error ? `?error=${error}` : ''
+                        }${
+                            code ? `?access_token=${code}` : ''
+                        }&provider=${provider}`
+                    )
+                }
 
             if (!access_token) return redirect(query.error)
 


### PR DESCRIPTION
We want devs to be able to hook into login / register flows. 

For example, maybe you want to cancel the login if the user's account is owing payments:

```js
auth()
   .afterLogin((ctx, user) => {
       if (user.payments.length === 0) {
            ctx.badInput(['Pay your bills.'])
       }
   })
```