### PR TITLE
fix(component): responsive sidebar now closes on backdrop and menu click

### DIFF
--- a/packages/cms/pages/Dashboard.tsx
+++ b/packages/cms/pages/Dashboard.tsx
@@ -36,7 +36,9 @@ const Dashboard: React.FC<DashboardProps> = () => {
                                     className="fixed inset-0"
                                     aria-hidden={!offCanvasOpen}
                                 >
-                                    <div className="absolute inset-0 bg-gray-600 opacity-75" />
+                                    <div className="absolute inset-0 bg-gray-600 opacity-75" 
+                                        onClick={() =>setOffCanvasOpen(!offCanvasOpen)}
+                                    />
                                 </div>
                             )}
                         </Transition.Child>
@@ -90,7 +92,7 @@ const Dashboard: React.FC<DashboardProps> = () => {
                                             />
                                         </div>
                                     </div>
-                                    <div className="mt-5 flex-1 h-0 overflow-y-auto">
+                                    <div className="mt-5 flex-1 h-0 overflow-y-auto" onClick={() =>setOffCanvasOpen(!offCanvasOpen)}>
                                         <Nav className="md:px-2 space-y-1" />
                                     </div>
                                 </div>


### PR DESCRIPTION
The responsive sidebar initially closes only when the close icon is clicked but now closes once the
backdrop is clicked as well as any item on the menu.