### PR TITLE
Fix/redirect users based on authentication status

### DIFF
--- a/packages/cms/pages/components/auth/guards/must-not-be-authenticated.tsx
+++ b/packages/cms/pages/components/auth/guards/must-not-be-authenticated.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Redirect } from 'react-router-dom'
 import { useAuthStore } from '../../../../store/auth'
 
-export const MustBeNotAuthComponent = (Component: React.FC) => {
+export const MustNotBeAuthComponent = (Component: React.FC) => {
   const { user } = useAuthStore()
 
   const Comp = (props: any) => {

--- a/packages/cms/pages/components/auth/routes/routes.tsx
+++ b/packages/cms/pages/components/auth/routes/routes.tsx
@@ -3,13 +3,17 @@ import { Route } from 'react-router-dom'
 
 import { Login } from '../../../auth/login'
 import { Register } from '../../../auth/register'
+import { MustNotBeAuthComponent } from '../guards/must-not-be-authenticated'
 
 export const AuthRoutes: React.FunctionComponent = () => {
   return (
     <>
-      <Route component={Login} path={window.Tensei.getPath('auth/login')} />
       <Route
-        component={Register}
+        component={MustNotBeAuthComponent(Login)}
+        path={window.Tensei.getPath('auth/login')}
+      />
+      <Route
+        component={MustNotBeAuthComponent(Register)}
         path={window.Tensei.getPath('auth/register')}
       />
     </>

--- a/packages/cms/pages/components/dashboard/routes/routes.tsx
+++ b/packages/cms/pages/components/dashboard/routes/routes.tsx
@@ -3,16 +3,21 @@ import { Route } from 'react-router-dom'
 
 import { Dashboard } from '../../../dashboard'
 import { Resource } from '../../../resources/resource'
+import { MustBeAuthComponent } from '../../auth/guards/must-be-authenticated'
 
 export const DashboardRoutes: React.FunctionComponent = () => {
   return (
     <>
       <Route
         exact
-        component={Resource}
+        component={MustBeAuthComponent(Resource)}
         path={window.Tensei.getPath('resources/:resource')}
       />
-      <Route exact component={Dashboard} path={window.Tensei.getPath('')} />
+      <Route
+        exact
+        component={MustBeAuthComponent(Dashboard)}
+        path={window.Tensei.getPath('')}
+      />
     </>
   )
 }

--- a/packages/cms/pages/components/settings/routes/routes.tsx
+++ b/packages/cms/pages/components/settings/routes/routes.tsx
@@ -2,13 +2,14 @@ import React from 'react'
 import { Route } from 'react-router-dom'
 
 import { Profile } from '../../../settings/profile'
+import { MustBeAuthComponent } from '../../auth/guards/must-be-authenticated'
 
 export const SettingsRoutes: React.FunctionComponent = () => {
   return (
     <>
       <Route
         exact
-        component={Profile}
+        component={MustBeAuthComponent(Profile)}
         path={window.Tensei.getPath('settings/profile')}
       />
     </>


### PR DESCRIPTION
### Redirect users based on authentication status

We want to restrict access to pages based on the user's authentication state.

1. If user is currently logged in, visiting /cms/auth/register or /cms/auth/login redirects the user back to /cms 

2. If user is not currently logged in, visiting any route under /cms should redirect the user back to /cms/auth/login

