### PR TITLE
feat: add filter table data

### DIFF
--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -24,11 +24,12 @@ export default tensei()
   .resources([
     resource('Product')
       .fields([
-        text('Name').rules('required').sortable(),
+        text('Name').rules('required').sortable().searchable(),
         slug('Slug')
           .creationRules('required', 'unique:slug')
           .unique()
-          .from('Name'),
+          .from('Name')
+          .searchable(),
         textarea('Description').creationRules('required', 'max:255'),
         integer('Price').rules('required').sortable(),
         belongsToMany('Category'),

--- a/packages/cms/pages/resources/resource/resource.tsx
+++ b/packages/cms/pages/resources/resource/resource.tsx
@@ -5,6 +5,7 @@ import { useParams, useHistory } from 'react-router-dom'
 import { EuiSpacer } from '@tensei/eui/lib/components/spacer'
 import { EuiPopover } from '@tensei/eui/lib/components/popover'
 import { EuiFieldText } from '@tensei/eui/lib/components/form/field_text'
+import { EuiFlexItem, EuiFlexGroup } from '@tensei/eui/lib/components/flex'
 import { EuiButtonEmpty, EuiButton } from '@tensei/eui/lib/components/button'
 import {
   EuiBasicTable,
@@ -211,12 +212,8 @@ interface TableProps {
 }
 
 export const Table: React.FunctionComponent<TableProps> = ({ search }) => {
-  const {
-    resource,
-    applyFilter,
-    fetchTableData,
-    deleteTableData
-  } = useResourceStore()
+  const { resource, applyFilter, fetchTableData, deleteTableData, filters } =
+    useResourceStore()
   const [pageSize, setPageSize] = useState(resource?.perPageOptions[0])
   const [pageIndex, setPageIndex] = useState(0)
   const [loading, setLoading] = useState(true)
@@ -252,7 +249,7 @@ export const Table: React.FunctionComponent<TableProps> = ({ search }) => {
 
   useEffect(() => {
     getData()
-  }, [resource, pageIndex, pageSize, sortField, sortDirection, search])
+  }, [resource, pageIndex, pageSize, sortField, sortDirection, search, filters])
 
   const { toast } = useToastStore()
 
@@ -416,7 +413,7 @@ export const Table: React.FunctionComponent<TableProps> = ({ search }) => {
 
 export const Resource: React.FunctionComponent = () => {
   const { push } = useHistory()
-  const { findResource, resource } = useResourceStore()
+  const { findResource, resource, filters, clearFilter } = useResourceStore()
   const { resource: resourceSlug } = useParams<{
     resource: string
   }>()
@@ -463,9 +460,22 @@ export const Resource: React.FunctionComponent = () => {
                   <FilterList />
                 </SearchAndFilterContainer>
               </HeaderContainer>
-
-              <EuiSpacer size="xl" />
-
+              <EuiSpacer size="m" />
+              <EuiFlexGroup gutterSize="s" alignItems="center">
+                {filters.map((filter, idx) => (
+                  <EuiFlexItem grow={false} key={idx}>
+                    <EuiButton
+                      color="primary"
+                      onClick={() => {
+                        clearFilter(filter)
+                      }}
+                    >
+                      {filter.clause.name}
+                    </EuiButton>
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+              <EuiSpacer size="m" />
               <Table search={search} />
             </TableWrapper>
           </PageWrapper>

--- a/packages/cms/pages/resources/resource/resource.tsx
+++ b/packages/cms/pages/resources/resource/resource.tsx
@@ -470,7 +470,8 @@ export const Resource: React.FunctionComponent = () => {
                         clearFilter(filter)
                       }}
                     >
-                      {filter.clause.name}
+                      {filter.field.name} {''}
+                      {filter.clause.name} {filter.value}
                     </EuiButton>
                   </EuiFlexItem>
                 ))}

--- a/packages/cms/pages/resources/resource/resource.tsx
+++ b/packages/cms/pages/resources/resource/resource.tsx
@@ -108,7 +108,7 @@ const FilterValue: React.FunctionComponent<{
 export const FilterList: React.FunctionComponent = () => {
   const [open, setOpen] = useState(false)
   const { resource, applyFilter } = useResourceStore()
-
+  const [filterDropdown, setFilterDropdown] = useState<Boolean>()
   const contextMenuPopoverId = useGeneratedHtmlId({
     prefix: 'contextMenuPopover'
   })
@@ -126,7 +126,8 @@ export const FilterList: React.FunctionComponent = () => {
     // For now, we won't support filtering by relationship fields.
     const fields =
       resource?.fields.filter(
-        field => !field.isRelationshipField && !field.isVirtual
+        field =>
+          !field.isRelationshipField && !field.isVirtual && field.isSearchable
       ) || []
 
     const getClausesForField = (field: FieldContract) => {
@@ -135,7 +136,7 @@ export const FilterList: React.FunctionComponent = () => {
       // be shown clauses with type of "number".
       return filterClauses
     }
-
+    fields.length ? setFilterDropdown(true) : setFilterDropdown(false)
     return [
       {
         id: 0,
@@ -180,7 +181,7 @@ export const FilterList: React.FunctionComponent = () => {
     ]
   }, [resource])
 
-  return (
+  return filterDropdown ? (
     <EuiPopover
       isOpen={open}
       id={contextMenuPopoverId}
@@ -199,7 +200,7 @@ export const FilterList: React.FunctionComponent = () => {
     >
       <EuiContextMenu initialPanelId={0} panels={panels}></EuiContextMenu>
     </EuiPopover>
-  )
+  ) : null
 }
 interface MetaData {
   page: number

--- a/packages/cms/store/resource.ts
+++ b/packages/cms/store/resource.ts
@@ -129,7 +129,7 @@ export const useResourceStore = create<ResourceState & ResourceMethods>(
             where: {
               _and: [
                 ...filters.map(item => ({
-                  [item.field.name.toLowerCase()]: {
+                  [item.field.databaseField]: {
                     [item.clause.shortName]: item.value
                   }
                 }))

--- a/packages/cms/store/resource.ts
+++ b/packages/cms/store/resource.ts
@@ -110,13 +110,13 @@ export const useResourceStore = create<ResourceState & ResourceMethods>(
       set({
         filters: get().filters.filter(
           activeFilter =>
-            activeFilter.field.databaseField === filter.field.databaseField
+            activeFilter.field.databaseField !== filter.field.databaseField
         )
       })
     },
 
     async fetchTableData(params: TableDataParams) {
-      const { resource } = get()
+      const { resource, filters } = get()
       const { page, perPage, sort, sortField, search } = params
 
       return window.Tensei.api.get(`/${resource?.slug}`, {
@@ -124,7 +124,18 @@ export const useResourceStore = create<ResourceState & ResourceMethods>(
           page,
           perPage,
           ...(sortField && { sort }),
-          ...(search && { search })
+          ...(search && { search }),
+          ...(filters.length && {
+            where: {
+              _and: [
+                ...filters.map(item => ({
+                  [item.field.name.toLowerCase()]: {
+                    [item.clause.shortName]: item.value
+                  }
+                }))
+              ]
+            }
+          })
         }
       })
     },


### PR DESCRIPTION
I'm wondering if we'll need to dynamically add the filter value in the case of fuzzy search or other cases?
the current implementation only matches `exact match`, `greater` or `less` than.
