### PR TITLE
Enhancement/cms 77 make the team member page responsive

### DIFF
--- a/packages/cms/pages/components/dashboard/layout/sidebar.tsx
+++ b/packages/cms/pages/components/dashboard/layout/sidebar.tsx
@@ -504,7 +504,7 @@ export const SidebarMenu: React.FunctionComponent<SidebarProps> = ({
   const [groups, setGroups] = useState(getGroups())
   const { mergePermissions, hasPermission } = useAuthStore()
 
-  const { setSidebarState, sidebarState } = useSidebarStore()
+  const { sidebarState, setSidebarState } = useSidebarStore()
   const onCloseSideBar = () => {
     setSidebarState(!sidebarState)
   }

--- a/packages/cms/pages/settings/team-members/team-members.tsx
+++ b/packages/cms/pages/settings/team-members/team-members.tsx
@@ -42,9 +42,26 @@ import { EuiFlexItem, EuiFlexGroup } from '@tensei/eui/lib/components/flex'
 import { useForm } from '../../hooks/forms'
 import { useAuthStore } from '../../../store/auth'
 import { useHistory } from 'react-router-dom'
+
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+
+  @media only screen and (max-width: 757px) {
+    .euiTable.euiTable--responsive
+      .euiTableRow.euiTableRow-isExpandable
+      .euiTableRowCell--isExpander,
+    .euiTable.euiTable--responsive
+      .euiTableRow.euiTableRow-hasActions
+      .euiTableRowCell--hasActions {
+      top: 76px;
+    }
+  }
+  @media only screen and (max-width: 712px) {
+    h1 {
+      display: none;
+    }
+  }
 `
 
 const PageWrapper = styled.div`
@@ -210,19 +227,13 @@ const FlyOut: React.FC<FlyOutProps> = ({
 
 export const TeamMembers: FunctionComponent<ProfileProps> = () => {
   const { toast } = useToastStore()
-  const {
-    getAdminUsers,
-    removeUser,
-    getAdminRoles,
-    updateUserRoles
-  } = useAdminUsersStore()
+  const { getAdminUsers, removeUser, getAdminRoles, updateUserRoles } =
+    useAdminUsersStore()
   const [teamMembers, setTeamMembers] = useState<TeamMemberProps[]>([])
   const [roles, setRoles] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
-  const [
-    isEditTeamMemberFlyoutVisible,
-    setisEditTeamMemberFlyoutVisible
-  ] = useState(false)
+  const [isEditTeamMemberFlyoutVisible, setisEditTeamMemberFlyoutVisible] =
+    useState(false)
   const { hasPermission } = useAuthStore()
 
   const getTeamMembers = useCallback(async () => {
@@ -288,28 +299,24 @@ export const TeamMembers: FunctionComponent<ProfileProps> = () => {
     updatedAt: ''
   })
 
-  const [isRemoveMemberModalVisible, setIsRemoveMemberModalVisible] = useState(
-    false
-  )
+  const [isRemoveMemberModalVisible, setIsRemoveMemberModalVisible] =
+    useState(false)
   const closeRemoveMemberModal = () => setIsRemoveMemberModalVisible(false)
   const showRemoveMemberModal = () => setIsRemoveMemberModalVisible(true)
-  const [
-    isChangeMemberRoleModalVisible,
-    setChangeMemberRoleModalVisible
-  ] = useState(false)
+  const [isChangeMemberRoleModalVisible, setChangeMemberRoleModalVisible] =
+    useState(false)
   const closeChangeMemberRoleModal = () =>
     setChangeMemberRoleModalVisible(false)
   const showChangeMemberRoleModal = () => setChangeMemberRoleModalVisible(true)
   const modalFormId = useGeneratedHtmlId({ prefix: 'modalForm' })
-  const [
-    rolesCheckboxSelectionMap,
-    setRolesCheckboxSelectionMap
-  ] = useState<any>({})
+  const [rolesCheckboxSelectionMap, setRolesCheckboxSelectionMap] =
+    useState<any>({})
 
   const columns: EuiBasicTableColumn<any>[] = useMemo(() => {
     return [
       {
         name: 'User',
+        truncateText: true,
         render: (item: any) => {
           return (
             <UserWrapper>
@@ -322,10 +329,24 @@ export const TeamMembers: FunctionComponent<ProfileProps> = () => {
               {isOwner(item) ? <OwnerBadge>Owner</OwnerBadge> : ''}
             </UserWrapper>
           )
+        },
+        mobileOptions: {
+          render: item => (
+            <>
+              <span>
+                {item.firstName} {item.lastName}
+              </span>
+              {isOwner(item) ? <OwnerBadge>Owner</OwnerBadge> : ''}
+            </>
+          ),
+          width: '100%',
+          enlarge: true,
+          truncateText: false
         }
       },
       {
         name: 'Role',
+        truncateText: true,
         render: (item: any) => {
           return item?.adminRoles.map((roles: any) => (
             <UserRole>{roles?.name}</UserRole>
@@ -377,9 +398,8 @@ export const TeamMembers: FunctionComponent<ProfileProps> = () => {
               const newCheckboxIdToSelectedMap: any = {}
               rolesId.forEach(
                 roleId =>
-                  (newCheckboxIdToSelectedMap[roleId] = adminRolesId.includes(
-                    roleId
-                  ))
+                  (newCheckboxIdToSelectedMap[roleId] =
+                    adminRolesId.includes(roleId))
               )
               setRolesCheckboxSelectionMap(newCheckboxIdToSelectedMap)
             }
@@ -535,6 +555,8 @@ export const TeamMembers: FunctionComponent<ProfileProps> = () => {
             hasActions={true}
             loading={loading}
             columns={columns}
+            responsive={true}
+            isExpandable={true}
           />
         )}
 

--- a/packages/cms/pages/settings/team-members/team-members.tsx
+++ b/packages/cms/pages/settings/team-members/team-members.tsx
@@ -46,6 +46,7 @@ import { useForm } from '../../hooks/forms'
 import { useAuthStore } from '../../../store/auth'
 import { useHistory } from 'react-router-dom'
 import { AbstractData } from '@tensei/components'
+import { useSidebarStore } from '../../../store/sidebar'
 
 const Wrapper = styled.div`
   display: flex;
@@ -83,7 +84,7 @@ const TableMetaWrapper = styled.div`
 const OwnerBadge = styled.div`
   margin-left: 2px;
   border-radius: 3px;
-  font-size: 12px;
+  font-size: 10px;
   padding: 4px 4px;
   line-height: 1rem;
   color: ${({ theme }) => theme.colors.primary};
@@ -99,7 +100,7 @@ const UserWrapper = styled.div`
   align-items: center;
 `
 const UserRole = styled.span`
-  margin-right: 10px;
+  margin-right: 5px;
 `
 
 const ClipBoardCallOut = styled(EuiCallOut)`


### PR DESCRIPTION
![localhost_8810_cms_settings_team-members(Pixel 2 XL)](https://user-images.githubusercontent.com/54292102/150957993-fba3b90a-381c-4ec2-b2a4-f795929e9652.png)
mobile view on pixel 2xl
![localhost_8810_cms_settings_team-members(iPhone X)](https://user-images.githubusercontent.com/54292102/150958002-f5add420-aeb9-497e-9793-8d5106f4a097.png)
mobile view on iphone X
I removed the number of team members from the mobile view.
I am also thinking of disabling the sidebar toggle on mobile, I don't know if it is the right way to go.
![localhost_8810_cms_settings_team-members(iPad) (2)](https://user-images.githubusercontent.com/54292102/150958600-bd3b47ef-1dc0-4da6-81b1-045df0805863.png)
![localhost_8810_cms_settings_team-members(iPad)](https://user-images.githubusercontent.com/54292102/150958611-c9b11e3d-c4e4-4418-91f5-b8bdbcee8d7b.png)

