### PR TITLE
Fix/cms 79 fix the belongs to many bug

### DIFF
--- a/packages/cms/index/id/id.tsx
+++ b/packages/cms/index/id/id.tsx
@@ -14,7 +14,7 @@ const BadgeInButton = styled(EuiBadge)`
 `
 const IndexId: React.FC<IndexComponentProps> = ({ value }) => {
   return (
-    <EuiCopy textToCopy={value}>
+    <EuiCopy textToCopy={value.toString()}>
       {copy => (
         <button onClick={copy}>
           <BadgeInButton color={'hollow'}>{value}</BadgeInButton>

--- a/packages/cms/pages/components/dashboard/layout/sidebar.tsx
+++ b/packages/cms/pages/components/dashboard/layout/sidebar.tsx
@@ -102,6 +102,8 @@ const NavItem = styled.div<{
   $active?: boolean
   to?: string
 }>`
+  cursor: pointer;
+
   display: flex;
   position: relative;
   align-items: center;
@@ -124,8 +126,7 @@ const NavItem = styled.div<{
       ? `
   color: ${theme.colors.primary};
   background-color:  ${theme.colors.primaryTransparent} ;
-  cursor: pointer;
-
+  
   svg {
     path {
       fill: ${theme.colors.primary};
@@ -449,10 +450,7 @@ const CollapsedSidebar: React.FC<CollpsedSidebarProps> = ({
             <EuiIcon type="help" size="m" />
           </NavItem>
           <EuiSpacer size="m" />
-          <NavItem
-            as={Link as any}
-            onClick={() => setIsConfirmModalVisible(true)}
-          >
+          <NavItem onClick={() => setIsConfirmModalVisible(true)}>
             <Exit />
           </NavItem>
         </EuiFlexGroup>
@@ -622,10 +620,7 @@ export const SidebarMenu: React.FunctionComponent<SidebarProps> = ({
           <EuiText>Help</EuiText>
         </NavItem>
         <EuiSpacer size="s" />
-        <NavItem
-          as={Link as any}
-          onClick={() => setIsConfirmModalVisible(true)}
-        >
+        <NavItem onClick={() => setIsConfirmModalVisible(true)}>
           <Exit />
           <EuiText color="danger">Logout</EuiText>
         </NavItem>

--- a/packages/cms/pages/resources/resource-form/resource-form.tsx
+++ b/packages/cms/pages/resources/resource-form/resource-form.tsx
@@ -161,7 +161,7 @@ export const UpdateResourceSidebar: React.FunctionComponent<{
         <Content>
           <EuiText size="s">ID</EuiText>
           {isEditing ? (
-            <EuiCopy textToCopy={resourceData?.id}>
+            <EuiCopy textToCopy={resourceData?.id.toString()}>
               {copy => (
                 <button onClick={copy}>
                   <BadgeInButton color="hollow">


### PR DESCRIPTION
When a user is logged into Tensei cms, user clicks on ¨reviews¨ on the resource page and clicks on ¨edit¨, the page goes blank.

This bug is caused by the Belongs to Many form component

This issue was fixed earlier but was reported to still be buggy.