### PR TITLE
Enhancement/cms 78 make the ¨roles permission¨ page

### DIFF
--- a/packages/cms/pages/components/dashboard/layout/sidebar.tsx
+++ b/packages/cms/pages/components/dashboard/layout/sidebar.tsx
@@ -303,6 +303,7 @@ interface CollpsedSidebarProps {
   SubNav: any[]
   isConfirmModalVisible: boolean
   setIsConfirmModalVisible: (confirmStatus: boolean) => void
+  width: number
 }
 
 const getGroups = () => {
@@ -377,14 +378,18 @@ const CollapsedSidebar: React.FC<CollpsedSidebarProps> = ({
   onLogout,
   isConfirmModalVisible,
   setIsConfirmModalVisible,
-  SubNav
+  SubNav,
+  width
 }) => {
   const [isContentPopoverOpen, setIsContentPopoverOpen] = useState(false)
+
   return (
     <CollapsedSidbarContainer>
-      <CollapseExpandIcon onClick={onCloseSidebar}>
-        <EuiIcon size="s" type="arrowRight" />
-      </CollapseExpandIcon>
+      {width > 720 ? (
+        <CollapseExpandIcon onClick={onCloseSidebar}>
+          <EuiIcon size="s" type="arrowRight" />
+        </CollapseExpandIcon>
+      ) : null}
       <SidebarContainer>
         <Workspace>
           <EuiFlexGroup direction="column" alignItems="center">
@@ -553,6 +558,22 @@ export const SidebarMenu: React.FunctionComponent<SidebarProps> = ({
     )
   })
 
+  const [width, setWidth] = useState(window.innerWidth)
+  const handleResize = () => setWidth(window.innerWidth)
+
+  useEffect(() => {
+    window.addEventListener('resize', handleResize)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [width])
+
+  useEffect(() => {})
+  if (width <= 720) {
+    if (sidebarState != false) {
+      setSidebarState(false)
+    }
+  }
   return sidebarState ? (
     <Sidebar>
       <CollapseExpandIcon onClick={onCloseSideBar}>
@@ -645,6 +666,7 @@ export const SidebarMenu: React.FunctionComponent<SidebarProps> = ({
       isConfirmModalVisible={isConfirmModalVisible}
       setIsConfirmModalVisible={setIsConfirmModalVisible}
       SubNav={SubNav}
+      width={width}
     />
   )
 }

--- a/packages/cms/pages/components/dashboard/layout/sidebar.tsx
+++ b/packages/cms/pages/components/dashboard/layout/sidebar.tsx
@@ -504,7 +504,7 @@ export const SidebarMenu: React.FunctionComponent<SidebarProps> = ({
   const [groups, setGroups] = useState(getGroups())
   const { mergePermissions, hasPermission } = useAuthStore()
 
-  const { setSidebarState, sidebarState } = useSidebarStore()
+  const { sidebarState, setSidebarState } = useSidebarStore()
   const onCloseSideBar = () => {
     setSidebarState(!sidebarState)
   }

--- a/packages/cms/pages/settings/roles-and-permissions/roles-and-permissions.tsx
+++ b/packages/cms/pages/settings/roles-and-permissions/roles-and-permissions.tsx
@@ -56,7 +56,13 @@ const RolesAndPermissionWrapper = styled.div`
 const TableHeading = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
   padding-left: 7px;
+  @media screen and (max-width: 720px) {
+    h1 {
+      font-size: 4vw;
+    }
+  }
 `
 const AccordionWrapper = styled.div`
   margin-bottom: 20px;
@@ -400,9 +406,8 @@ const RolesTable: React.FC = () => {
   const [loading, setLoading] = useState(true)
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false)
   const { getAdminUsers, getAdminRoles, removeRole } = useAdminUsersStore()
-  const [isRemoveRoleModalVisible, setIsRemoveRoleModalVisible] = useState(
-    false
-  )
+  const [isRemoveRoleModalVisible, setIsRemoveRoleModalVisible] =
+    useState(false)
   const { toast } = useToastStore()
   const { hasPermission } = useAuthStore()
 

--- a/packages/cms/pages/settings/root/root.tsx
+++ b/packages/cms/pages/settings/root/root.tsx
@@ -18,6 +18,9 @@ const StyledLayout = styled.div`
 
 const TabsWrapper = styled.div`
   padding: 20px 40px 0 40px;
+  @media screen and (max-width: 420px){
+    padding 20px 20px 0 20px
+  }
 `
 
 const tabs = [

--- a/packages/cms/pages/settings/root/root.tsx
+++ b/packages/cms/pages/settings/root/root.tsx
@@ -18,8 +18,12 @@ const StyledLayout = styled.div`
 
 const TabsWrapper = styled.div`
   padding: 20px 40px 0 40px;
-  @media screen and (max-width: 420px){
-    padding 20px 20px 0 20px
+
+  @media screen and (max-width: 420px) {
+    padding 20px 20px 0 20px;
+    .euiTab + .euiTab {
+      margin-left: 10px;
+    }
   }
 `
 


### PR DESCRIPTION
made the roles and permission page responsive
i added a useEffect to switch to collapsed sidebar and disable toggling in mobile view

![localhost_8810_cms_settings_roles-and-permissions(iPad) (1)](https://user-images.githubusercontent.com/54292102/151006869-dd7296f9-58fd-4f12-99b5-755728a87bf4.png)
![localhost_8810_cms_settings_roles-and-permissions(iPad)](https://user-images.githubusercontent.com/54292102/151006881-4612d287-dea8-4824-9404-829209b6410b.png)
ipad view.
![localhost_8810_cms_settings_roles-and-permissions(Pixel 2 XL)](https://user-images.githubusercontent.com/54292102/151011436-ba0fbf3d-2e7f-4199-9565-708bd470fc16.png)
![localhost_8810_cms_settings_roles-and-permissions(iPhone X)](https://user-images.githubusercontent.com/54292102/151011452-2e7d95a3-d5dd-42cb-8068-889903ef2531.png)

