### PR TITLE
refactor: fixed registration error messages

### DIFF
--- a/packages/cms/plugin/index.ts
+++ b/packages/cms/plugin/index.ts
@@ -413,7 +413,9 @@ class CmsPlugin {
       })
       .validationMessages({
         'firstName.required': 'The first name is required.',
-        'lastName.required': 'The last name is required.'
+        'lastName.required': 'The last name is required.',
+        'email.required': 'The email is required.',
+        'password.required': 'The password is required.',
       })
   }
 

--- a/packages/cms/plugin/index.ts
+++ b/packages/cms/plugin/index.ts
@@ -411,6 +411,10 @@ class CmsPlugin {
           })
         }
       })
+      .validationMessages({
+        'firstName.required': 'The first name is required.',
+        'lastName.required': 'The last name is required.'
+      })
   }
 
   sessionMikroOrmOptions = {

--- a/packages/tests/packages/cms/admin.spec.ts
+++ b/packages/tests/packages/cms/admin.spec.ts
@@ -192,7 +192,7 @@ test('cannot register administrator with only some valid data', async () => {
         field: 'firstName'
       },
       {
-        message: 'The last ame is required.',
+        message: 'The last name is required.',
         validation: 'required',
         field: 'lastName'
       }

--- a/packages/tests/packages/cms/admin.spec.ts
+++ b/packages/tests/packages/cms/admin.spec.ts
@@ -133,12 +133,12 @@ test('cannot register administrator without all valid data', async () => {
   expect(response.body).toEqual({
     errors: [
       {
-        message: 'The firstName is required.',
+        message: 'The first name is required.',
         validation: 'required',
         field: 'firstName'
       },
       {
-        message: 'The lastName is required.',
+        message: 'The last name is required.',
         validation: 'required',
         field: 'lastName'
       },
@@ -187,12 +187,12 @@ test('cannot register administrator with only some valid data', async () => {
   expect(response.body).toEqual({
     errors: [
       {
-        message: 'The firstName is required.',
+        message: 'The first name is required.',
         validation: 'required',
         field: 'firstName'
       },
       {
-        message: 'The lastName is required.',
+        message: 'The last ame is required.',
         validation: 'required',
         field: 'lastName'
       }


### PR DESCRIPTION
Given that John wants to register his account and he is trying to put his credentials 

when John inputs his first name incorrectly, John should see an error message ¨The first name is required¨
when John inputs his last name incorrectly, John see an error message ¨The last name is required¨